### PR TITLE
Manage duplicated endpoint name

### DIFF
--- a/packages/react/src/components/try-api/enhanced-credentials-form.tsx
+++ b/packages/react/src/components/try-api/enhanced-credentials-form.tsx
@@ -157,7 +157,7 @@ export const EnhancedCredentialsForm: React.FC = () => {
 							variant="ghost"
 							size="sm"
 							onClick={() => setShowPassword(!showPassword)}
-							className="hover:bg-accent absolute right-0.5"
+							className="hover:bg-accent absolute right-0.5 bg-background"
 						>
 							{showPassword ? (
 								<EyeOff className="h-4 w-4" />

--- a/packages/react/src/components/try-api/response-display.tsx
+++ b/packages/react/src/components/try-api/response-display.tsx
@@ -159,7 +159,7 @@ export const ResponseDisplay: React.FC<ResponseDisplayProps> = ({
 							</Tabs.List>
 						)}
 						<Tabs.Content value="response">
-							<div className="bg-card p-4 rounded-md text-sm font-mono overflow-x-auto text-foreground border max-h-64 overflow-y-auto">
+							<div className="bg-card p-4 rounded-md text-sm font-mono overflow-x-auto text-foreground border max-h-[450px] overflow-y-auto">
 								{highlightedData && (
 									<Pre code={highlightedData} handlers={[lineNumbers]} />
 								)}

--- a/packages/react/src/components/ui/custom-object-field.tsx
+++ b/packages/react/src/components/ui/custom-object-field.tsx
@@ -8,16 +8,26 @@ interface CustomObjectFieldProps {
 	bodyPath: (string | number)[];
 	field: SchemaObject;
 	readOnly: boolean;
-	name: string;
 }
 
 type field = {
 	id: string;
 	field: [string, string];
 };
-const CustomObjectField: React.FC<CustomObjectFieldProps> = ({ bodyPath }) => {
+const CustomObjectField: React.FC<CustomObjectFieldProps> = ({
+	bodyPath,
+	readOnly,
+}) => {
 	const [fields, setFields] = useState<Array<field>>([]);
 	const { updateBodyParam } = useRequestParams();
+
+	if (readOnly) {
+		return (
+			<div className="py-2 px-4 border-t ">
+				<span className="text-sm text-muted-foreground">Custom object</span>
+			</div>
+		);
+	}
 
 	const updateStore = (updatedFields: Array<field>) => {
 		const obj: Record<string, string> = Object.fromEntries(

--- a/packages/react/src/components/ui/custom-object-field.tsx
+++ b/packages/react/src/components/ui/custom-object-field.tsx
@@ -1,0 +1,110 @@
+import type { SchemaObject } from "@/core/types";
+import { useRequestParams } from "@/index";
+import { Button, Input } from "@rhinolabs/ui";
+import { Plus, Trash } from "lucide-react";
+import { useState } from "react";
+
+interface CustomObjectFieldProps {
+	bodyPath: (string | number)[];
+	field: SchemaObject;
+	readOnly: boolean;
+	name: string;
+}
+
+type field = {
+	id: string;
+	field: [string, string];
+};
+const CustomObjectField: React.FC<CustomObjectFieldProps> = ({ bodyPath }) => {
+	const [fields, setFields] = useState<Array<field>>([]);
+	const { updateBodyParam } = useRequestParams();
+
+	const updateStore = (updatedFields: Array<field>) => {
+		const obj: Record<string, string> = Object.fromEntries(
+			updatedFields.map((f) => f.field),
+		);
+		updateBodyParam(bodyPath, obj);
+	};
+
+	return (
+		<div className="p-2 border-t space-y-2">
+			{fields.map(({ id, field: [key, value] }) => (
+				<div
+					className="flex justify-between items-center w-full cursor-pointer border rounded-lg px-2 py-2 gap-2"
+					key={id}
+				>
+					<div className="flex gap-2 items-center">
+						<Input
+							className="border bg-input text-foreground lg:min-w-[200px]"
+							placeholder="Key"
+							type="text"
+							value={key}
+							onChange={(e) => {
+								const newKey = e.target.value;
+								setFields((prev) => {
+									const updatedFields = prev.map((field) =>
+										field.id === id
+											? { ...field, field: [newKey, field.field[1]] }
+											: field,
+									) as field[];
+
+									updateStore(updatedFields);
+
+									return updatedFields;
+								});
+							}}
+						/>
+						<span>:</span>
+						<Input
+							className="border bg-input text-foreground lg:min-w-[300px]"
+							placeholder="Value"
+							type="text"
+							value={value}
+							onChange={(e) => {
+								const newValue = e.target.value;
+								setFields((prev) => {
+									const updatedFields = prev.map((field) =>
+										field.id === id
+											? { ...field, field: [field.field[0], newValue] }
+											: field,
+									) as field[];
+
+									updateStore(updatedFields);
+
+									return updatedFields;
+								});
+							}}
+						/>
+					</div>
+					<Button
+						variant="ghost"
+						size="sm"
+						className="w-9 p-0 bg-transparent hover:bg-destructive group"
+						onClick={() => {
+							setFields((prev) => prev.filter((field) => field.id !== id));
+						}}
+					>
+						<Trash className="h-4 w-4 text-muted-foreground group-hover:text-destructive-foreground" />
+						<span className="sr-only">Delete</span>
+					</Button>
+				</div>
+			))}
+			<Button
+				variant="secondary"
+				className="w-full rounded-lg justify-center gap-2 h-[40px]"
+				onClick={() => {
+					// Add new empty field
+					setFields((prev) => [
+						...prev,
+						{ id: Date.now().toString(), field: ["", ""] },
+					]);
+				}}
+			>
+				ADD FIELD
+				<Plus />
+			</Button>
+		</div>
+	);
+};
+
+export { CustomObjectField };

--- a/packages/react/src/components/ui/fields/object-field.tsx
+++ b/packages/react/src/components/ui/fields/object-field.tsx
@@ -4,8 +4,8 @@ import { Button, Collapsible, Separator } from "@rhinolabs/ui";
 import { ChevronRight } from "lucide-react";
 import { useState } from "react";
 import React from "react";
-import { ParamField } from "./param-field";
 import { CustomObjectField } from "../custom-object-field";
+import { ParamField } from "./param-field";
 
 interface ObjectFieldProps {
 	field: SchemaObject;

--- a/packages/react/src/components/ui/fields/object-field.tsx
+++ b/packages/react/src/components/ui/fields/object-field.tsx
@@ -117,7 +117,6 @@ export const ObjectField: React.FC<ObjectFieldProps> = ({
 								bodyPath={bodyPath}
 								field={field}
 								readOnly={readOnly}
-								name={name}
 							/>
 						)}
 					</div>

--- a/packages/react/src/components/ui/fields/object-field.tsx
+++ b/packages/react/src/components/ui/fields/object-field.tsx
@@ -1,10 +1,11 @@
-import type { SchemaObject } from "@/types/api/openapi";
+import type { SchemaObject, SchemaOrRef } from "@/types/api/openapi";
 import { asSchemaObject } from "@/utils/type-guards";
 import { Button, Collapsible, Separator } from "@rhinolabs/ui";
 import { ChevronRight } from "lucide-react";
 import { useState } from "react";
 import React from "react";
 import { ParamField } from "./param-field";
+import { CustomObjectField } from "../custom-object-field";
 
 interface ObjectFieldProps {
 	field: SchemaObject;
@@ -15,8 +16,49 @@ interface ObjectFieldProps {
 	bodyPath?: (string | number)[];
 }
 
-const isObjectField = (field: SchemaObject): boolean =>
-	field.type === "object" && !!field.properties;
+const isObjectField = (field: SchemaObject): boolean => field.type === "object";
+
+interface SchemaObjectFieldProps {
+	propertyEntries: [string, SchemaOrRef][];
+	bodyPath: (string | number)[];
+	field: SchemaObject;
+	readOnly: boolean;
+	name: string;
+}
+
+const SchemaObjectField: React.FC<SchemaObjectFieldProps> = ({
+	propertyEntries,
+	bodyPath,
+	field,
+	readOnly,
+	name,
+}) => {
+	return propertyEntries.map(([propName, subSchemaOrRef]) => {
+		const subSchema = asSchemaObject(subSchemaOrRef);
+		if (!subSchema) return null;
+
+		// Construct nested bodyPath for this property
+		const nestedBodyPath =
+			bodyPath.length > 0 ? [...bodyPath, propName] : [name, propName];
+
+		return (
+			<React.Fragment key={propName}>
+				<Separator />
+				<ParamField
+					field={{
+						name: propName,
+						in: "body",
+						required: field.required?.includes(propName) ?? false,
+						schema: subSchema,
+						description: subSchema.description,
+					}}
+					readOnly={readOnly}
+					bodyPath={nestedBodyPath}
+				/>
+			</React.Fragment>
+		);
+	});
+};
 
 export const ObjectField: React.FC<ObjectFieldProps> = ({
 	field,
@@ -32,13 +74,11 @@ export const ObjectField: React.FC<ObjectFieldProps> = ({
 		return null;
 	}
 
+	const hasSchemaProperties = !!field.properties;
+
 	const propertyEntries = field.properties
 		? Object.entries(field.properties)
 		: [];
-
-	if (propertyEntries.length === 0) {
-		return null;
-	}
 
 	return (
 		<div className="col-span-4">
@@ -64,33 +104,22 @@ export const ObjectField: React.FC<ObjectFieldProps> = ({
 				</div>
 				<Collapsible.Content>
 					<div className="overflow-hidden rounded-b-lg bg-background/50">
-						{propertyEntries.map(([propName, subSchemaOrRef]) => {
-							const subSchema = asSchemaObject(subSchemaOrRef);
-							if (!subSchema) return null;
-
-							// Construct nested bodyPath for this property
-							const nestedBodyPath =
-								bodyPath.length > 0
-									? [...bodyPath, propName]
-									: [name, propName];
-
-							return (
-								<React.Fragment key={propName}>
-									<Separator />
-									<ParamField
-										field={{
-											name: propName,
-											in: "body",
-											required: field.required?.includes(propName) ?? false,
-											schema: subSchema,
-											description: subSchema.description,
-										}}
-										readOnly={readOnly}
-										bodyPath={nestedBodyPath}
-									/>
-								</React.Fragment>
-							);
-						})}
+						{hasSchemaProperties ? (
+							<SchemaObjectField
+								propertyEntries={propertyEntries}
+								bodyPath={bodyPath}
+								field={field}
+								readOnly={readOnly}
+								name={name}
+							/>
+						) : (
+							<CustomObjectField
+								bodyPath={bodyPath}
+								field={field}
+								readOnly={readOnly}
+								name={name}
+							/>
+						)}
 					</div>
 				</Collapsible.Content>
 			</Collapsible>

--- a/packages/react/src/components/ui/fields/string-field.tsx
+++ b/packages/react/src/components/ui/fields/string-field.tsx
@@ -30,13 +30,14 @@ export const StringField: React.FC<StringFieldProps> = ({
 		if (readOnly) return;
 
 		if (paramType === "path") {
-			updatePathParam(name, value);
+			updatePathParam(name, newValue);
 		} else if (paramType === "query") {
-			updateQueryParam(name, value);
+			updateQueryParam(name, newValue);
 		} else if (paramType === "body") {
 			const path = bodyPath.length > 0 ? bodyPath : [name];
-			updateBodyParam(path, value);
+			updateBodyParam(path, newValue);
 		}
+
 		setValue(newValue);
 	};
 

--- a/packages/react/src/contexts/openapi-context.tsx
+++ b/packages/react/src/contexts/openapi-context.tsx
@@ -67,7 +67,9 @@ export function OpenAPIProvider({
 			currentSlug,
 			availableAuthTypes,
 			getOperationBySlug: (slug: string): EnhancedOperation | null => {
-				return openApiService.findOperationBySlug(spec, slug);
+				const split = slug.split("_");
+				const index = split[1] ? Number.parseInt(split[1], 10) : 0;
+				return openApiService.findOperationBySlug(spec, split[0], index);
 			},
 		};
 	}, [spec, baseUrl, currentSlug]);

--- a/packages/react/src/hooks/use-sidebar-data.ts
+++ b/packages/react/src/hooks/use-sidebar-data.ts
@@ -15,6 +15,7 @@ import { useMemo } from "react";
 interface SidebarData {
 	collections: SidebarCollection[];
 	totalEndpoints: number;
+	currentSlug?: string;
 	specInfo: {
 		title: string;
 		version: string;
@@ -59,7 +60,19 @@ const generateSidebarFromSpec = (
 			if (!tagGroups.has(tag)) {
 				tagGroups.set(tag, []);
 			}
-			tagGroups.get(tag)?.push(item);
+
+			const group = tagGroups.get(tag);
+			const existingItem = group?.find((i) => i.url === item.url);
+
+			if (!existingItem) {
+				group?.push(item);
+			} else {
+				const currentIndex = Number.parseInt(existingItem.url.split("_")[1]);
+				const nextIndex = Number.isNaN(currentIndex) ? 1 : currentIndex + 1;
+
+				item.url = `${item.url}_${nextIndex}`;
+				group?.push(item);
+			}
 		}
 	}
 

--- a/packages/react/src/services/openapi-service.ts
+++ b/packages/react/src/services/openapi-service.ts
@@ -44,7 +44,7 @@ export class OpenApiService {
 
 				if (operationSlug === slug) {
 					if (count === index) {
-					return { ...operation, path, method: method.toUpperCase() };
+						return { ...operation, path, method: method.toUpperCase() };
 					}
 					count++;
 				}

--- a/packages/react/src/services/openapi-service.ts
+++ b/packages/react/src/services/openapi-service.ts
@@ -30,7 +30,10 @@ export class OpenApiService {
 	findOperationBySlug(
 		spec: OpenApiDocument,
 		slug: string,
+		index = 0,
 	): EnhancedOperation | null {
+		let count = 0;
+
 		for (const [path, pathItem] of Object.entries(spec.paths)) {
 			for (const [method, operation] of Object.entries(pathItem)) {
 				if (!operation) continue;
@@ -40,7 +43,10 @@ export class OpenApiService {
 				);
 
 				if (operationSlug === slug) {
+					if (count === index) {
 					return { ...operation, path, method: method.toUpperCase() };
+					}
+					count++;
 				}
 			}
 		}


### PR DESCRIPTION
 - No schema object param
 - PATH PARAMS not setting correctly in the curl section when changing it in the central section (example organizationId in [Get a list of events for an organization] endpoint)
 - Duplicated name of endpoint (key/path)