### PR TITLE
Add Umami analytics tracking

### DIFF
--- a/apps/docs/src/layouts/Layout.astro
+++ b/apps/docs/src/layouts/Layout.astro
@@ -20,6 +20,7 @@ const { title } = Astro.props as Props;
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="generator" content={Astro.generator} />
     <title>{title}</title>
+    <script defer src="https://cloud.umami.is/script.js" data-website-id="fd2975ad-9f8f-4359-bf11-423f3c2a8700" is:inline></script>
   </head>
   <body class="min-h-screen overflow-x-hidden antialiased bg-background text-foreground">
     <main id="app" class="relative flex min-h-screen flex-col">


### PR DESCRIPTION
Implement Umami analytics tracking on all documentation pages. The tracking script is added to the main Layout component with defer loading to avoid blocking page render.